### PR TITLE
Fix receive key from ftok by filename

### DIFF
--- a/src/AsyncTask.php
+++ b/src/AsyncTask.php
@@ -71,6 +71,12 @@ abstract class AsyncTask
     private $line;
 
     /**
+     * The current class file
+     * @var string
+     */
+    private $file;
+
+    /**
      * Creates a new asynchronous task
      * @return void
      * @access public
@@ -99,7 +105,10 @@ abstract class AsyncTask
         $line = debug_backtrace();
         $this->line = $line[0]['line'];
 
-        self::$shmId = shm_attach((int) (ftok(__FILE__, 'A') . $this->line));
+        $reflect =  new \ReflectionClass($this);
+        $this->file =  $reflect->getFileName();
+
+        self::$shmId = shm_attach((int) (ftok($this->file, 'A') . $this->line));
         shm_put_var(self::$shmId, 11511697116117115, 'PENDING');
         shm_put_var(self::$shmId, 112112105100, getmypid());
     }
@@ -191,7 +200,7 @@ abstract class AsyncTask
         if ($pid == -1) {
             exit();
         } elseif (!$pid) {
-            self::$shmId = shm_attach((int) (ftok(__FILE__, 'A') . $this->line));
+            self::$shmId = shm_attach((int) (ftok($this->file, 'A') . $this->line));
             shm_put_var(self::$shmId, 112105100, getmypid());
             shm_put_var(self::$shmId, 11511697116117115, 'RUNNING');
 


### PR DESCRIPTION
`__FILE__` - return full path and filename of the file with symlinks resolved. If used inside an include, the name of the included file is returned.
So, if  you need start many tasks (different clasess extends AsyncTask) - you have the same key for every script based on path AsynkTask.php filename.
Use ReflectionClass you receive always unique shmid based by file path Class who extends AsyncTask 
